### PR TITLE
length is defined as an unsigned two-byte number

### DIFF
--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -37,7 +37,7 @@ const int OPC_BUFFER_SIZE = OPC_MAX_PIXELS * 3 + OPC_HEADER_BYTES;
 //------------------------------------------------------------------------------
 
 // Callback when a full OPC Message has been received
-void cbOpcMessage(uint8_t channel, uint8_t command, uint8_t length, uint8_t* data) {
+void cbOpcMessage(uint8_t channel, uint8_t command, uint16_t length, uint8_t* data) {
   Serial.print("chn:");
   Serial.print(channel);
   Serial.print("cmd:");

--- a/src/Opc.h
+++ b/src/Opc.h
@@ -53,6 +53,6 @@ struct OpcClient {
   uint8_t* buffer;
 };
 
-typedef void (*OpcMsgReceivedCallback)(uint8_t channel, uint8_t command, uint8_t length, uint8_t* data);
+typedef void (*OpcMsgReceivedCallback)(uint8_t channel, uint8_t command, uint16_t length, uint8_t* data);
 typedef void (*OpcClientConnectedCallback)(WiFiClient&);
 typedef void (*OpcClientDisconnectedCallback)(OpcClient&);

--- a/src/OpcServer.h
+++ b/src/OpcServer.h
@@ -13,7 +13,7 @@ class OpcServer {
             uint8_t clientSize,
             uint8_t buffer[],
             uint32_t bufferSize,
-            OpcMsgReceivedCallback opcMsgReceivedCallback = [](uint8_t channel, uint8_t command, uint8_t length, uint8_t* data) -> void {},
+            OpcMsgReceivedCallback opcMsgReceivedCallback = [](uint8_t channel, uint8_t command, uint16_t length, uint8_t* data) -> void {},
             OpcClientConnectedCallback opcClientConnectedCallback = [](WiFiClient&) -> void {},
             OpcClientDisconnectedCallback opcClientDisconnectedCallback = [](OpcClient&) -> void {});
 


### PR DESCRIPTION
The message data block can have any length from 0 to 65535 therefore an
uint16_t is required to pass the length correctly to the callback
function.
