### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 
 OpcServer	KEYWORD1
 OpcClient	KEYWORD1
-OpcMessage KEYWORD1
+OpcMessage	KEYWORD1
 
 #######################################
 # Methods and Functions
 #######################################
 
-begin KEYWORD2
+begin	KEYWORD2
 process	KEYWORD2
 
 getBufferSize	KEYWORD2
 getBufferSizeInPixels	KEYWORD2
-getBytesAvailable KEYWORD2
+getBytesAvailable	KEYWORD2
 getClientCount	KEYWORD2
 getClientSize	KEYWORD2
 
@@ -28,10 +28,10 @@ setMsgReceivedCallback	KEYWORD2
 #######################################
 # Constants
 #######################################
-OPC_SET_PIXEL_COLORS			LITERAL1
-OPC_SYSTEM_EXCLUSIVE		LITERAL1
+OPC_SET_PIXEL_COLORS	LITERAL1
+OPC_SYSTEM_EXCLUSIVE	LITERAL1
 
-OPC_GLOBAL_COLOR_CORRECTION		LITERAL1
-OPC_FIRMWARE_CONFIGURATION		LITERAL1
+OPC_GLOBAL_COLOR_CORRECTION	LITERAL1
+OPC_FIRMWARE_CONFIGURATION	LITERAL1
 
-OPC_HEADER_BYTES			LITERAL1
+OPC_HEADER_BYTES	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords